### PR TITLE
ESTS-136448 Enabled preprocess workflow for multinode

### DIFF
--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/InventoryScaleIO.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/InventoryScaleIO.java
@@ -7,6 +7,8 @@ package com.dell.cpsd.paqx.dne.service.delegates;
 
 import com.dell.cpsd.paqx.dne.repository.DataServiceRepository;
 import com.dell.cpsd.paqx.dne.service.NodeService;
+import com.dell.cpsd.paqx.dne.service.model.ComponentEndpointIds;
+import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +16,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
+
+import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.INVENTORY_SCALE_IO_FAILED;
+import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.SCALE_IO_INFORMATION_NOT_FOUND;
 
 @Component
 @Scope("prototype")
@@ -43,10 +48,10 @@ public class InventoryScaleIO extends BaseWorkflowDelegate
     {
         LOGGER.info("Execute Inventory ScaleIO");
 
-        /*ComponentEndpointIds componentEndpointIds = new ComponentEndpointIds("1", "2", "3", "4");
+        ComponentEndpointIds componentEndpointIds = null;
         try
         {
-            //componentEndpointIds = repository.getComponentEndpointIds("SCALEIO");
+            componentEndpointIds = repository.getComponentEndpointIds("SCALEIO-CLUSTER");
         }
         catch (Exception e)
         {
@@ -67,8 +72,8 @@ public class InventoryScaleIO extends BaseWorkflowDelegate
         boolean success = true;
         try
         {
-            //success = this.nodeService.requestDiscoverScaleIo(componentEndpointIds,
-            //                                                  delegateExecution.getProcessInstanceId());
+            success = this.nodeService.requestDiscoverScaleIo(componentEndpointIds,
+                                                              delegateExecution.getProcessInstanceId());
         }
         catch (Exception e)
         {
@@ -85,7 +90,7 @@ public class InventoryScaleIO extends BaseWorkflowDelegate
             LOGGER.error("Request for Inventory Scale IO failed.");
             updateDelegateStatus("Inventory request for Scale IO Failed.");
             throw new BpmnError(INVENTORY_SCALE_IO_FAILED, "Inventory request for Scale IO Failed.");
-        }*/
+        }
         LOGGER.info("Request for Inventory Scale IO completed successfully.");
         updateDelegateStatus("Inventory request for Scale IO completed successfully.");
 

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/InventoryVCenter.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/InventoryVCenter.java
@@ -18,6 +18,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.INVENTORY_VCENTER_FAILED;
+import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.VCENTER_INFORMATION_NOT_FOUND;
 
 @Component
 @Scope("prototype")
@@ -47,10 +48,10 @@ public class InventoryVCenter extends BaseWorkflowDelegate
     {
         LOGGER.info("Execute Inventory VCenter");
 
-        ComponentEndpointIds componentEndpointIds = new ComponentEndpointIds("1", "2", "3","4");
+        ComponentEndpointIds componentEndpointIds = null;
         try
         {
-            //componentEndpointIds = repository.getVCenterComponentEndpointIdsByEndpointType("VCENTER-CUSTOMER");
+            componentEndpointIds = repository.getVCenterComponentEndpointIdsByEndpointType("VCENTER-CUSTOMER");
         }
         catch (Exception e)
         {
@@ -60,7 +61,7 @@ public class InventoryVCenter extends BaseWorkflowDelegate
             throw new BpmnError(INVENTORY_VCENTER_FAILED,
                                 "An Unexpected Exception occurred attempting to inventory VCenter.  Reason: " +
                                 e.getMessage());
-        }/*
+        }
         if (componentEndpointIds == null)
         {
             LOGGER.error("VCenter Endpoints not found.");
@@ -71,8 +72,8 @@ public class InventoryVCenter extends BaseWorkflowDelegate
         boolean success = true;
         try
         {
-            //success = this.nodeService.requestDiscoverVCenter(componentEndpointIds,
-            //                                                  delegateExecution.getProcessInstanceId());
+            success = this.nodeService.requestDiscoverVCenter(componentEndpointIds,
+                                                              delegateExecution.getProcessInstanceId());
         }
         catch (Exception e)
         {
@@ -88,7 +89,7 @@ public class InventoryVCenter extends BaseWorkflowDelegate
             LOGGER.error("Request for Inventory VCenter failed");
             updateDelegateStatus("Inventory request for VCenter Failed.");
             throw new BpmnError(INVENTORY_VCENTER_FAILED, "Inventory request for VCenter Failed.");
-        }*/
+        }
         LOGGER.info("Request for Inventory VCenter completed successfully.");
         updateDelegateStatus("Inventory request for VCenter completed successfully.");
     }

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/RetrieveScaleIoComponents.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/RetrieveScaleIoComponents.java
@@ -6,6 +6,7 @@
 package com.dell.cpsd.paqx.dne.service.delegates;
 
 import com.dell.cpsd.paqx.dne.service.NodeService;
+import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,6 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
+
+import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.RETRIEVE_SCALE_IO_COMPONENTS_FAILED;
 
 @Component
 @Scope("prototype")
@@ -40,7 +43,7 @@ public class RetrieveScaleIoComponents extends BaseWorkflowDelegate
     {
         LOGGER.info("Execute Retrieve ScaleIO Components");
 
-/*        boolean succeeded;
+        boolean succeeded;
         try
         {
             succeeded = this.nodeService.requestScaleIoComponents();
@@ -59,7 +62,7 @@ public class RetrieveScaleIoComponents extends BaseWorkflowDelegate
             LOGGER.error("Scale IO Components were not retrieved.");
             updateDelegateStatus("Scale IO Components were not retrieved.");
             throw new BpmnError(RETRIEVE_SCALE_IO_COMPONENTS_FAILED, "Scale IO Components were not retrieved.");
-        }*/
+        }
         LOGGER.info("Scale IO Components were retrieved successfully.");
         updateDelegateStatus("Scale IO Components were retrieved successfully.");
 

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/RetrieveVCenterComponents.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/RetrieveVCenterComponents.java
@@ -6,6 +6,7 @@
 package com.dell.cpsd.paqx.dne.service.delegates;
 
 import com.dell.cpsd.paqx.dne.service.NodeService;
+import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,6 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
+
+import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.RETRIEVE_VCENTER_COMPONENTS_FAILED;
 
 @Component
 @Scope("prototype")
@@ -40,7 +43,7 @@ public class RetrieveVCenterComponents extends BaseWorkflowDelegate
     {
         LOGGER.info("Execute List VCenter Components");
         boolean succeeded;
-       /* try
+        try
         {
             succeeded = this.nodeService.requestVCenterComponents();
         }
@@ -58,7 +61,7 @@ public class RetrieveVCenterComponents extends BaseWorkflowDelegate
             LOGGER.error("VCenter Components were not retrieved.");
             updateDelegateStatus("VCenter Components were not retrieved.");
             throw new BpmnError(RETRIEVE_VCENTER_COMPONENTS_FAILED, "VCenter Components were not retrieved.");
-        }*/
+        }
         LOGGER.info("VCenter Components were retrieved successfully.");
         updateDelegateStatus("VCenter Components were retrieved successfully.");
 

--- a/dne-paqx/src/main/resources/processes/PreProcess.bpmn
+++ b/dne-paqx/src/main/resources/processes/PreProcess.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.8.2">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.10.0">
   <bpmn:process id="preProcess" name="Pre Process" isExecutable="true" camunda:versionTag="1.0">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1xg9b7l</bpmn:outgoing>
@@ -24,7 +24,7 @@
       <bpmn:outgoing>SequenceFlow_0zultiu</bpmn:outgoing>
       <bpmn:errorEventDefinition camunda:errorCodeVariable="errorCode" camunda:errorMessageVariable="errorMessage" />
     </bpmn:boundaryEvent>
-    <bpmn:serviceTask id="handleError" name="Handle Error" camunda:asyncBefore="true" camunda:asyncAfter="true" camunda:exclusive="false" camunda:class="com.dell.cpsd.paqx.service.delegates.HandleError">
+    <bpmn:serviceTask id="handleError" name="Handle Error" camunda:asyncBefore="true" camunda:asyncAfter="true" camunda:exclusive="false" camunda:class="com.dell.cpsd.paqx.dne.service.delegates.HandleError">
       <bpmn:incoming>SequenceFlow_09p3mp4</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1q1kgtz</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1yufucj</bpmn:incoming>


### PR DESCRIPTION
Workflow includes:
- retrieve ScaleIO components
- retrieve vCenter components
- inventory ScaleIO
- inventory vCenter

Workflow can be invoked by POST /multinode/preprocess with empty body. Response includes workflow Job ID.
Workflow status is available by GET /multinode/status/{jobid}