### PR TITLE
ESTS-316827 Fix NPE if no storage pools found

### DIFF
--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/task/handler/preprocess/FindOrCreateValidStoragePoolTaskHandler.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/task/handler/preprocess/FindOrCreateValidStoragePoolTaskHandler.java
@@ -211,7 +211,7 @@ public class FindOrCreateValidStoragePoolTaskHandler extends BaseTaskHandler imp
         storageResponseMessage.getWarnings().forEach(f -> response.addWarning(f.getMessage()));
 
         // if all devices are allocated to existing pools or some of the disks already allocated or < 90GB and no errors
-        if (storageResponseMessage.getDeviceToStoragePoolMap().size() == newDevices.size() || CollectionUtils
+        if (CollectionUtils.size(storageResponseMessage.getDeviceToStoragePoolMap()) == CollectionUtils.size(newDevices) || CollectionUtils
                 .isEmpty(storageResponseMessage.getErrors()))
         {
             LOGGER.info("Storage pool validated successfully.");


### PR DESCRIPTION
DNE should create a new SSD storage pool if none are found, but the
current code was throwing an NPE in this scenario.