### PR TITLE
ESTS-136453 Enabled workflow for multi-node up to "configure boot device"

### DIFF
--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/ConfigIdracIpAddress.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/ConfigIdracIpAddress.java
@@ -8,6 +8,9 @@ package com.dell.cpsd.paqx.dne.service.delegates;
 
 import com.dell.cpsd.paqx.dne.service.NodeService;
 import com.dell.cpsd.paqx.dne.service.delegates.model.NodeDetail;
+import com.dell.cpsd.paqx.dne.service.model.IdracInfo;
+import com.dell.cpsd.paqx.dne.service.model.IdracNetworkSettingsRequest;
+import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +19,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.CONFIGURE_IP_ADDRESS_FAILED;
 import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.NODE_DETAIL;
 
 @Component
@@ -46,7 +50,7 @@ public class ConfigIdracIpAddress extends BaseWorkflowDelegate
         NodeDetail nodeDetail = (NodeDetail) delegateExecution.getVariable(NODE_DETAIL);
         final String taskMessage = "Configure IP Address";
         
-        /*IdracInfo idracInfo = null;
+        IdracInfo idracInfo = null;
         try
         {
             IdracNetworkSettingsRequest idracNetworkSettingsRequest = new IdracNetworkSettingsRequest();
@@ -76,7 +80,7 @@ public class ConfigIdracIpAddress extends BaseWorkflowDelegate
             throw new BpmnError(CONFIGURE_IP_ADDRESS_FAILED,
                                 taskMessage + " on Node " + nodeDetail.getServiceTag() + " failed!  Reason: " +
                                 idracInfo.getMessage());
-        }*/
+        }
         LOGGER.info(taskMessage + " on Node " + nodeDetail.getServiceTag() + " was successful.");
         updateDelegateStatus(taskMessage + " on Node " + nodeDetail.getServiceTag() + " was successful.");
     }

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/ConfigureNodeCredentials.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/ConfigureNodeCredentials.java
@@ -8,6 +8,8 @@ package com.dell.cpsd.paqx.dne.service.delegates;
 
 import com.dell.cpsd.paqx.dne.service.NodeService;
 import com.dell.cpsd.paqx.dne.service.delegates.model.NodeDetail;
+import com.dell.cpsd.paqx.dne.service.model.ChangeIdracCredentialsResponse;
+import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +18,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.INSTALL_ESXI_FAILED;
 import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.NODE_DETAIL;
 
 @Component
@@ -52,7 +55,7 @@ public class ConfigureNodeCredentials extends BaseWorkflowDelegate
         final String taskMessage = "Configure Node Credentials";
         NodeDetail nodeDetail = (NodeDetail) delegateExecution.getVariable(NODE_DETAIL);
 
-        /*final String symphonuUuid = nodeDetail.getId();
+        final String symphonuUuid = nodeDetail.getId();
         ChangeIdracCredentialsResponse responseMessage = null;
         try
         {
@@ -73,7 +76,7 @@ public class ConfigureNodeCredentials extends BaseWorkflowDelegate
             updateDelegateStatus(taskMessage + " on Node " + nodeDetail.getServiceTag() + " failed!");
             throw new BpmnError(INSTALL_ESXI_FAILED,
                                 taskMessage + " on Node " + nodeDetail.getServiceTag() + " failed!");
-        }*/
+        }
         LOGGER.info(taskMessage + " on Node " + nodeDetail.getServiceTag() + " was successful.");
         updateDelegateStatus(taskMessage + " on Node " + nodeDetail.getServiceTag() + " was successful.");
 

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/ConfigureObmSettings.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/ConfigureObmSettings.java
@@ -6,8 +6,13 @@
 
 package com.dell.cpsd.paqx.dne.service.delegates;
 
+import com.dell.cpsd.ObmConfig;
+import com.dell.cpsd.SetObmSettingsRequestMessage;
 import com.dell.cpsd.paqx.dne.service.NodeService;
 import com.dell.cpsd.paqx.dne.service.delegates.model.NodeDetail;
+import com.dell.cpsd.paqx.dne.service.model.ObmSettingsResponse;
+import java.util.Arrays;
+import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +21,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.CONFIGURE_OBM_SETTINGS_FAILED;
 import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.NODE_DETAIL;
 
 @Component
@@ -53,7 +59,7 @@ public class ConfigureObmSettings extends BaseWorkflowDelegate
 
         NodeDetail nodeDetail = (NodeDetail) delegateExecution.getVariable(NODE_DETAIL);
 
-     /*   ObmSettingsResponse obmSettingsResponse = null;
+        ObmSettingsResponse obmSettingsResponse = null;
         try
         {
             String uuid = nodeDetail.getId();
@@ -86,7 +92,7 @@ public class ConfigureObmSettings extends BaseWorkflowDelegate
             updateDelegateStatus("Obm Settings on Node " + nodeDetail.getServiceTag() + " were not configured.");
             throw new BpmnError(CONFIGURE_OBM_SETTINGS_FAILED,
                                 "Obm Settings on Node " + nodeDetail.getServiceTag() + " were not configured.");
-        }*/
+        }
         LOGGER.info("Obm Settings on Node " + nodeDetail.getServiceTag() + " were configured successfully.");
         updateDelegateStatus("Obm Settings on Node " + nodeDetail.getServiceTag() + " were configured successfully.");
 

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/VerifyNodeDetail.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/VerifyNodeDetail.java
@@ -47,7 +47,6 @@ public class VerifyNodeDetail extends BaseWorkflowDelegate
         if (StringUtils.isBlank(nodeDetail.getServiceTag())) {
             missingFields.add("serviceTag");
         }
-        /*
         if (StringUtils.isBlank(nodeDetail.getIdracIpAddress())) {
             missingFields.add("idracIpAddress");
         }
@@ -66,14 +65,11 @@ public class VerifyNodeDetail extends BaseWorkflowDelegate
         if (StringUtils.isBlank(nodeDetail.getEsxiManagementSubnetMask())) {
             missingFields.add("esxiManagementSubnetMask");
         }
-        if (StringUtils.isBlank(nodeDetail.getEsxiManagementHostname()) {
+        if (StringUtils.isBlank(nodeDetail.getEsxiManagementHostname())) {
             missingFields.add("esxiManagementHostname");
         }
         if (StringUtils.isBlank(nodeDetail.getScaleIoData1SvmIpAddress())) {
             missingFields.add("scaleIoDataSvmIpAddress");
-        }
-        if (StringUtils.isBlank(nodeDetail.getScaleIoData1KernelIpAddress())) {
-            missingFields.add("scaleIoData1KernelIpAddress");
         }
         if (StringUtils.isBlank(nodeDetail.getScaleIoSvmData1SubnetMask())) {
             missingFields.add("scaleIoSvmData1SubnetMask");
@@ -96,9 +92,9 @@ public class VerifyNodeDetail extends BaseWorkflowDelegate
         if (StringUtils.isBlank(nodeDetail.getScaleIoSvmManagementSubnetMask())) {
             missingFields.add("scaleIoSvmManagementSubnetMask");
         }
-        if (StringUtils.isBlank(nodeDetail.getHostname())) {
-            missingFields.add("hostname");
-        }
+        //if (StringUtils.isBlank(nodeDetail.getHostname())) {
+        //    missingFields.add("hostname");
+        //}
         if (StringUtils.isBlank(nodeDetail.getClusterName())) {
             missingFields.add("clusterName");
         }
@@ -108,10 +104,9 @@ public class VerifyNodeDetail extends BaseWorkflowDelegate
         if (StringUtils.isBlank(nodeDetail.getvMotionManagementSubnetMask())) {
             missingFields.add("vMotionManagementSubnetMask");
         }
-        if (StringUtils.isBlank(nodeDetail.getProtectionDomain())) {
-            missingFields.add("protectionDomain");
-        }
-*/
+        //if (StringUtils.isBlank(nodeDetail.getProtectionDomain())) {
+        //    missingFields.add("protectionDomain");
+        //}
         if (CollectionUtils.isNotEmpty(missingFields)) {
             final String message = "Node details are incomplete!  Please update Node details with the following information and try again.  Missing values for " + StringUtils.join(missingFields, ", ") + ".";
             LOGGER.error(message);

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/model/NodeDetail.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/model/NodeDetail.java
@@ -146,12 +146,12 @@ public class NodeDetail implements Serializable
         this.scaleIoData1KernelIpAddress = scaleIoData1KernelIpAddress;
     }
 
-    public String getscaleIoSvmData1SubnetMask()
+    public String getScaleIoSvmData1SubnetMask()
     {
         return scaleIoSvmData1SubnetMask;
     }
 
-    public void setscaleIoSvmData1SubnetMask(final String scaleIoSvmData1SubnetMask)
+    public void setScaleIoSvmData1SubnetMask(final String scaleIoSvmData1SubnetMask)
     {
         this.scaleIoSvmData1SubnetMask = scaleIoSvmData1SubnetMask;
     }
@@ -176,12 +176,12 @@ public class NodeDetail implements Serializable
         this.scaleIoData2KernelIpAddress = scaleIoData2KernelIpAddress;
     }
 
-    public String getscaleIoSvmData2SubnetMask()
+    public String getScaleIoSvmData2SubnetMask()
     {
         return scaleIoSvmData2SubnetMask;
     }
 
-    public void setscaleIoSvmData2SubnetMask(final String scaleIoSvmData2SubnetMask)
+    public void setScaleIoSvmData2SubnetMask(final String scaleIoSvmData2SubnetMask)
     {
         this.scaleIoSvmData2SubnetMask = scaleIoSvmData2SubnetMask;
     }

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/request/SendConfigureBootDeviceRequest.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/request/SendConfigureBootDeviceRequest.java
@@ -26,7 +26,7 @@ import static com.dell.cpsd.paqx.dne.service.delegates.utils.DelegateConstants.S
 
 @Component
 @Scope("prototype")
-@Qualifier("configureBootDevice")
+@Qualifier("configureBootDeviceRequest")
 public class SendConfigureBootDeviceRequest extends BaseWorkflowDelegate
 {
     /**

--- a/dne-paqx/src/main/resources/processes/AddNode.bpmn
+++ b/dne-paqx/src/main/resources/processes/AddNode.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.8.2">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.10.0">
   <bpmn:process id="addNode" name="Add Node" isExecutable="true" camunda:versionTag="1.0">
     <bpmn:startEvent id="StartEvent_1gjhh65">
       <bpmn:outgoing>SequenceFlow_1x7cq92</bpmn:outgoing>
@@ -250,7 +250,7 @@
     <bpmn:boundaryEvent id="notifyNodeDiscoveryToUpdateStatusError" name="Error" camunda:asyncAfter="true" camunda:exclusive="false" attachedToRef="notifyNodeDiscoveryToUpdateStatus">
       <bpmn:errorEventDefinition camunda:errorCodeVariable="errorCode" camunda:errorMessageVariable="errorMessage" />
     </bpmn:boundaryEvent>
-    <bpmn:endEvent id="EndEvent_1ymjmsr">
+    <bpmn:endEvent id="EndEvent_1ymjmsr" camunda:asyncBefore="true">
       <bpmn:incoming>SequenceFlow_1wnen9i</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="SequenceFlow_1uijh8k" sourceRef="addHostToDvSwitch" targetRef="deployScaleIOVm" />

--- a/dne-paqx/src/main/resources/processes/PreProcess.bpmn
+++ b/dne-paqx/src/main/resources/processes/PreProcess.bpmn
@@ -12,7 +12,7 @@
       <bpmn:incoming>SequenceFlow_0tv1vs3</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_13a3p0g</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="EndEvent_1cl1kmi">
+    <bpmn:endEvent id="EndEvent_1cl1kmi" camunda:asyncBefore="true">
       <bpmn:incoming>SequenceFlow_0zxr1q6</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_13a3p0g</bpmn:incoming>
     </bpmn:endEvent>


### PR DESCRIPTION
Enabled tasks. Fixed bean qualifier. Added "async" property for end event in "add node" subprocess - it is necessary to maintain correct activity state in case of error.