### PR TITLE
ESTS-137545 Fix inconsistent scaleio subnet mask names

### DIFF
--- a/dne-paqx-web/src/test/java/com/dell/cpsd/paqx/dne/rest/NodeExpansionWebApplicationTest.java
+++ b/dne-paqx-web/src/test/java/com/dell/cpsd/paqx/dne/rest/NodeExpansionWebApplicationTest.java
@@ -82,7 +82,7 @@ public class NodeExpansionWebApplicationTest
         request.setIdracIpAddress("4.4.4.4");
         request.setIdracSubnetMask("5.55.5.5");
         request.setEsxiManagementSubnetMask("6.66.6.6");
-        request.setScaleIoSvmData1SubnetMask("7.7.7.7");
+        request.setScaleIoData1SubnetMask("7.7.7.7");
         request.setScaleIoData1SvmIpAddress("9.99.9.9");
         request.setSymphonyUuid(UUID.randomUUID().toString());
 
@@ -109,8 +109,8 @@ public class NodeExpansionWebApplicationTest
         params.setEsxiManagementSubnetMask("1.1.1.1");
         assertNotNull(params.getEsxiManagementSubnetMask());
 
-        params.setScaleIoSvmData1SubnetMask("1.1.1.1");
-        assertNotNull(params.getScaleIoSvmData1SubnetMask());
+        params.setScaleIoData1SubnetMask("1.1.1.1");
+        assertNotNull(params.getScaleIoData1SubnetMask());
 
         params.setScaleIoData1SvmIpAddress("1.1.1.1");
         assertNotNull(params.getScaleIoData1SvmIpAddress());

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/AddHostToDvSwitch.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/AddHostToDvSwitch.java
@@ -63,9 +63,9 @@ public class AddHostToDvSwitch extends BaseWorkflowDelegate
         final String vMotionManagementIpAddress = nodeDetail.getvMotionManagementIpAddress();
         final String vMotionManagementSubnetMask = nodeDetail.getvMotionManagementSubnetMask();
         final String scaleIoData1SvmIpAddress = nodeDetail.getScaleIoData1SvmIpAddress();
-        final String scaleIoSvmData1SubnetMask = nodeDetail.getScaleIoSvmData1SubnetMask();
+        final String scaleIoSvmData1SubnetMask = nodeDetail.getScaleIoData1SubnetMask();
         final String scaleIoData2SvmIpAddress = nodeDetail.getScaleIoData2SvmIpAddress();
-        final String scaleIoSvmData2SubnetMask = nodeDetail.getScaleIoSvmData2SubnetMask();
+        final String scaleIoSvmData2SubnetMask = nodeDetail.getScaleIoData2SubnetMask();
 
         final Map<String, String> dvSwitchNames = repository.getDvSwitchNames();
         String[] switches = {DVSWITCH0_NAME, DVSWITCH1_NAME, DVSWITCH2_NAME};

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/DeployScaleIOVm.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/delegates/DeployScaleIOVm.java
@@ -357,7 +357,7 @@ public class DeployScaleIOVm extends BaseWorkflowDelegate
                 throw new IllegalStateException("ScaleIO Data1 IP Address is null");
             }
 
-            final String scaleIoSvmData1SubnetMask = this.inputParams.getScaleIoSvmData1SubnetMask();
+            final String scaleIoSvmData1SubnetMask = this.inputParams.getScaleIoData1SubnetMask();
 
             if (StringUtils.isEmpty(scaleIoSvmData1SubnetMask))
             {
@@ -371,7 +371,7 @@ public class DeployScaleIOVm extends BaseWorkflowDelegate
                 throw new IllegalStateException("ScaleIO Data2 IP Address is null");
             }
 
-            final String scaleIoSvmData2SubnetMask = this.inputParams.getScaleIoSvmData2SubnetMask();
+            final String scaleIoSvmData2SubnetMask = this.inputParams.getScaleIoData2SubnetMask();
 
             if (StringUtils.isEmpty(scaleIoSvmData2SubnetMask))
             {

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/model/NodeExpansionRequest.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/model/NodeExpansionRequest.java
@@ -21,9 +21,9 @@ public class NodeExpansionRequest
     private String esxiManagementHostname;
 
     private String scaleIoData1SvmIpAddress;
-    private String scaleIoSvmData1SubnetMask;
+    private String scaleIoData1SubnetMask;
     private String scaleIoData2SvmIpAddress;
-    private String scaleIoSvmData2SubnetMask;
+    private String scaleIoData2SubnetMask;
     private String scaleIoSvmManagementIpAddress;
     private String scaleIoSvmManagementGatewayAddress;
     private String scaleIoSvmManagementSubnetMask;
@@ -42,8 +42,8 @@ public class NodeExpansionRequest
 
     public NodeExpansionRequest(String idracIpAddress, String idracGatewayIpAddress, String idracSubnetMask, String esxiManagementIpAddress,
             String esxiManagementGatewayIpAddress, String esxiManagementSubnetMask, String esxiManagementHostname,
-            String scaleIoData1SvmIpAddress, String scaleIoSvmData1SubnetMask, String scaleIoData2SvmIpAddress,
-            String scaleIoSvmData2SubnetMask, String scaleIoSvmManagementIpAddress, String scaleIoSvmManagementGatewayAddress,
+            String scaleIoData1SvmIpAddress, String scaleIoData1SubnetMask, String scaleIoData2SvmIpAddress,
+            String scaleIoData2SubnetMask, String scaleIoSvmManagementIpAddress, String scaleIoSvmManagementGatewayAddress,
             String scaleIoSvmManagementSubnetMask, String symphonyUuid, String clusterName, String vMotionManagementIpAddress,
             String vMotionManagementSubnetMask, Map<String, DeviceAssignment> deviceToDeviceStoragePool)
     {
@@ -56,9 +56,9 @@ public class NodeExpansionRequest
         this.esxiManagementHostname = esxiManagementHostname;
         this.scaleIoData1SvmIpAddress = scaleIoData1SvmIpAddress;
         this.scaleIoSvmManagementGatewayAddress = scaleIoSvmManagementGatewayAddress;
-        this.scaleIoSvmData1SubnetMask = scaleIoSvmData1SubnetMask;
+        this.scaleIoData1SubnetMask = scaleIoData1SubnetMask;
         this.scaleIoData2SvmIpAddress = scaleIoData2SvmIpAddress;
-        this.scaleIoSvmData2SubnetMask = scaleIoSvmData2SubnetMask;
+        this.scaleIoData2SubnetMask = scaleIoData2SubnetMask;
         this.scaleIoSvmManagementIpAddress = scaleIoSvmManagementIpAddress;
         this.scaleIoSvmManagementSubnetMask = scaleIoSvmManagementSubnetMask;
         this.symphonyUuid = symphonyUuid;
@@ -198,24 +198,24 @@ public class NodeExpansionRequest
         this.symphonyUuid = symphonyUuid;
     }
 
-    public String getScaleIoSvmData1SubnetMask()
+    public String getScaleIoData1SubnetMask()
     {
-        return scaleIoSvmData1SubnetMask;
+        return scaleIoData1SubnetMask;
     }
 
-    public void setScaleIoSvmData1SubnetMask(final String scaleIoSvmData1SubnetMask)
+    public void setScaleIoData1SubnetMask(final String scaleIoData1SubnetMask)
     {
-        this.scaleIoSvmData1SubnetMask = scaleIoSvmData1SubnetMask;
+        this.scaleIoData1SubnetMask = scaleIoData1SubnetMask;
     }
 
-    public String getScaleIoSvmData2SubnetMask()
+    public String getScaleIoData2SubnetMask()
     {
-        return scaleIoSvmData2SubnetMask;
+        return scaleIoData2SubnetMask;
     }
 
-    public void setScaleIoSvmData2SubnetMask(final String scaleIoSvmData2SubnetMask)
+    public void setScaleIoData2SubnetMask(final String scaleIoData2SubnetMask)
     {
-        this.scaleIoSvmData2SubnetMask = scaleIoSvmData2SubnetMask;
+        this.scaleIoData2SubnetMask = scaleIoData2SubnetMask;
     }
 
     public String getScaleIoSvmManagementSubnetMask()
@@ -285,9 +285,9 @@ public class NodeExpansionRequest
                 + '\'' + ", idracSubnetMask='" + idracSubnetMask + '\'' + ", esxiManagementIpAddress='" + esxiManagementIpAddress + '\''
                 + ", esxiManagementGatewayIpAddress='" + esxiManagementGatewayIpAddress + '\'' + ", esxiManagementSubnetMask='"
                 + esxiManagementSubnetMask + '\'' + ", esxiManagementHostname='" + esxiManagementHostname + '\''
-                + ", scaleIoData1SvmIpAddress='" + scaleIoData1SvmIpAddress + '\'' + ", scaleIoSvmData1SubnetMask='"
-                + scaleIoSvmData1SubnetMask + '\'' + ", scaleIoData2SvmIpAddress='" + scaleIoData2SvmIpAddress + '\''
-                + ", scaleIoSvmData2SubnetMask='" + scaleIoSvmData2SubnetMask + '\'' + ", scaleIoSvmManagementIpAddress='"
+                + ", scaleIoData1SvmIpAddress='" + scaleIoData1SvmIpAddress + '\'' + ", scaleIoData1SubnetMask='"
+                + scaleIoData1SubnetMask + '\'' + ", scaleIoData2SvmIpAddress='" + scaleIoData2SvmIpAddress + '\''
+                + ", scaleIoData2SubnetMask='" + scaleIoData2SubnetMask + '\'' + ", scaleIoSvmManagementIpAddress='"
                 + scaleIoSvmManagementIpAddress + '\'' + ", scaleIoSvmManagementGatewayAddress='" + scaleIoSvmManagementGatewayAddress
                 + '\'' + ", scaleIoSvmManagementSubnetMask='" + scaleIoSvmManagementSubnetMask + '\'' + ", clusterName='" + clusterName
                 + '\'' + ", symphonyUuid='" + symphonyUuid + '\'' + ", vMotionManagementIpAddress='" + vMotionManagementIpAddress + '\''

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/task/handler/addnode/AddHostToDvSwitchTaskHandler.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/task/handler/addnode/AddHostToDvSwitchTaskHandler.java
@@ -115,7 +115,7 @@ public class AddHostToDvSwitchTaskHandler extends BaseTaskHandler implements IWo
                 throw new IllegalStateException("ScaleIO Data1 IP Address is null or empty");
             }
 
-            final String scaleIoSvmData1SubnetMask = inputParams.getScaleIoSvmData1SubnetMask();
+            final String scaleIoSvmData1SubnetMask = inputParams.getScaleIoData1SubnetMask();
             if (StringUtils.isEmpty(scaleIoSvmData1SubnetMask))
             {
                 throw new IllegalStateException("ScaleIO Data1 Subnet Mask is null or empty");
@@ -128,7 +128,7 @@ public class AddHostToDvSwitchTaskHandler extends BaseTaskHandler implements IWo
                 throw new IllegalStateException("ScaleIO Data2 IP Address is null or empty");
             }
 
-            final String scaleIoSvmData2SubnetMask = inputParams.getScaleIoSvmData2SubnetMask();
+            final String scaleIoSvmData2SubnetMask = inputParams.getScaleIoData2SubnetMask();
             if (StringUtils.isEmpty(scaleIoSvmData2SubnetMask))
             {
                 throw new IllegalStateException("ScaleIO Data2 Subnet Mask is null or empty");

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/task/handler/addnode/DeployScaleIoVmTaskHandler.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/task/handler/addnode/DeployScaleIoVmTaskHandler.java
@@ -406,7 +406,7 @@ public class DeployScaleIoVmTaskHandler extends BaseTaskHandler implements IWork
                 throw new IllegalStateException("ScaleIO Data1 IP Address is null");
             }
 
-            final String scaleIoSvmData1SubnetMask = this.inputParams.getScaleIoSvmData1SubnetMask();
+            final String scaleIoSvmData1SubnetMask = this.inputParams.getScaleIoData1SubnetMask();
 
             if (StringUtils.isEmpty(scaleIoSvmData1SubnetMask))
             {
@@ -420,7 +420,7 @@ public class DeployScaleIoVmTaskHandler extends BaseTaskHandler implements IWork
                 throw new IllegalStateException("ScaleIO Data2 IP Address is null");
             }
 
-            final String scaleIoSvmData2SubnetMask = this.inputParams.getScaleIoSvmData2SubnetMask();
+            final String scaleIoSvmData2SubnetMask = this.inputParams.getScaleIoData2SubnetMask();
 
             if (StringUtils.isEmpty(scaleIoSvmData2SubnetMask))
             {

--- a/dne-paqx/src/test/java/com/dell/cpsd/paqx/dne/service/task/handler/addnode/AddHostToDvSwitchTaskHandlerTest.java
+++ b/dne-paqx/src/test/java/com/dell/cpsd/paqx/dne/service/task/handler/addnode/AddHostToDvSwitchTaskHandlerTest.java
@@ -110,9 +110,9 @@ public class AddHostToDvSwitchTaskHandlerTest
         doReturn("1.1.1.1").when(this.inputParams).getvMotionManagementIpAddress();
         doReturn("2.2.2.2").when(this.inputParams).getvMotionManagementSubnetMask();
         doReturn("3.3.3.3").when(this.inputParams).getScaleIoData1SvmIpAddress();
-        doReturn("4.4.4.4").when(this.inputParams).getScaleIoSvmData1SubnetMask();
+        doReturn("4.4.4.4").when(this.inputParams).getScaleIoData1SubnetMask();
         doReturn("5.5.5.5").when(this.inputParams).getScaleIoData2SvmIpAddress();
-        doReturn("6.6.6.6").when(this.inputParams).getScaleIoSvmData2SubnetMask();
+        doReturn("6.6.6.6").when(this.inputParams).getScaleIoData2SubnetMask();
         doReturn(this.dvSwitchNames).when(this.repository).getDvSwitchNames();
         doReturn("dvswitch0").when(this.dvSwitchNames).get("dvswitch0");
         doReturn("dvswitch1").when(this.dvSwitchNames).get("dvswitch1");
@@ -214,9 +214,9 @@ public class AddHostToDvSwitchTaskHandlerTest
         doReturn("1.1.1.1").when(this.inputParams).getvMotionManagementIpAddress();
         doReturn("2.2.2.2").when(this.inputParams).getvMotionManagementSubnetMask();
         doReturn("3.3.3.3").when(this.inputParams).getScaleIoData1SvmIpAddress();
-        doReturn("4.4.4.4").when(this.inputParams).getScaleIoSvmData1SubnetMask();
+        doReturn("4.4.4.4").when(this.inputParams).getScaleIoData1SubnetMask();
         doReturn("5.5.5.5").when(this.inputParams).getScaleIoData2SvmIpAddress();
-        doReturn("6.6.6.6").when(this.inputParams).getScaleIoSvmData2SubnetMask();
+        doReturn("6.6.6.6").when(this.inputParams).getScaleIoData2SubnetMask();
         doReturn(this.dvSwitchNames).when(this.repository).getDvSwitchNames();
         doReturn("dvswitch0").when(this.dvSwitchNames).get("dvswitch0");
         doReturn("dvswitch1").when(this.dvSwitchNames).get("dvswitch1");

--- a/dne-paqx/src/test/java/com/dell/cpsd/paqx/dne/service/task/handler/addnode/DeployScaleIoVmTaskHandlerTest.java
+++ b/dne-paqx/src/test/java/com/dell/cpsd/paqx/dne/service/task/handler/addnode/DeployScaleIoVmTaskHandlerTest.java
@@ -137,9 +137,9 @@ public class DeployScaleIoVmTaskHandlerTest
         doReturn(this.sioMgmtSubnetMask).when(this.request).getScaleIoSvmManagementSubnetMask();
         doReturn(this.scaleIOSVMManagementGatewayAddress).when(this.request).getScaleIoSvmManagementGatewayAddress();
         doReturn(this.sioData1IpAddress).when(this.request).getScaleIoData1SvmIpAddress();
-        doReturn(this.sioData1SubnetMask).when(this.request).getScaleIoSvmData1SubnetMask();
+        doReturn(this.sioData1SubnetMask).when(this.request).getScaleIoData1SubnetMask();
         doReturn(this.sioData2IpAddress).when(this.request).getScaleIoData2SvmIpAddress();
-        doReturn(this.sioData2SubnetMask).when(this.request).getScaleIoSvmData2SubnetMask();
+        doReturn(this.sioData2SubnetMask).when(this.request).getScaleIoData2SubnetMask();
 
         doReturn(true).when(this.service).requestDeployScaleIoVm(any());
 
@@ -471,9 +471,9 @@ public class DeployScaleIoVmTaskHandlerTest
         doReturn(this.esxiManagementGatewayIpAddress).when(this.request).getEsxiManagementGatewayIpAddress();
         doReturn(this.sioMgmtSubnetMask).when(this.request).getScaleIoSvmManagementSubnetMask();
         doReturn(this.sioData1IpAddress).when(this.request).getScaleIoData1SvmIpAddress();
-        doReturn(this.sioData1SubnetMask).when(this.request).getScaleIoSvmData1SubnetMask();
+        doReturn(this.sioData1SubnetMask).when(this.request).getScaleIoData1SubnetMask();
         doReturn(this.sioData2IpAddress).when(this.request).getScaleIoData2SvmIpAddress();
-        doReturn(this.sioData2SubnetMask).when(this.request).getScaleIoSvmData2SubnetMask();
+        doReturn(this.sioData2SubnetMask).when(this.request).getScaleIoData2SubnetMask();
         doReturn(false).when(this.service).requestDeployScaleIoVm(any());
 
         boolean result = this.handler.executeTask(this.job);


### PR DESCRIPTION
There should be only a scaleio data 1 subnet mask and a scaleio
data 2 subnet mask. The masks refer to the network, not whether
it is used for an ESXi VMK or a SVM. Also need to match the field
names used in the UI.