### PR TITLE
ESTS-137584 Workaround for spring properties error

### DIFF
--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/amqp/config/RabbitConfig.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/amqp/config/RabbitConfig.java
@@ -115,20 +115,15 @@ public class RabbitConfig
 
     // following envs are for ESS communication. For now, ESS is internal service so no capability registration.
     // DNE gets exchanges, queue, routing key from properties file.
-    @Value("${ess.req.exchange.name}")
-    private String              essRequestExchange;
+    private String              essRequestExchange = "exchange.dell.cpsd.service.ess.request";
 
-    @Value("${ess.req.routing.prefix}")
-    private String              essReqRoutingKeyPrefix;
+    private String              essReqRoutingKeyPrefix = "ess.service.request";
 
-    @Value("${ess.res.exchange.name}")
-    private String              essResponseExchange;
+    private String              essResponseExchange = "exchange.dell.cpsd.service.ess.response";
 
-    @Value("${ess.res.queue}")
-    private String              essResQueue;
+    private String              essResQueue = "queue.dell.cpsd.ess.service.response";
 
-    @Value("${ess.res.routing.prefix}")
-    private String              essRespRoutingKeyPrefix;
+    private String              essRespRoutingKeyPrefix = "ess.service.response";
     /*
      * The RabbitMQ connection factory
      */

--- a/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/workflow/preprocess/PreProcessService.java
+++ b/dne-paqx/src/main/java/com/dell/cpsd/paqx/dne/service/workflow/preprocess/PreProcessService.java
@@ -48,8 +48,7 @@ public class PreProcessService extends BaseService implements IPreProcessService
     @Autowired
     private DataServiceRepository repository;
 
-    @Value("${obm.services}")
-    private String[] obmServices;
+    private String[] obmServices = { "dell-wsman-obm-service", "ipmi-obm-service" };
 
     private static final int PING_IDRAC_TIMEOUT = 120000; // 120 seconds
 


### PR DESCRIPTION
In q3stable branch DNE startup started failing for no clear reason
with `Could not resolve placeholder 'ess.req.exchange.name' in value
"${ess.req.exchange.name}"`. That value is just a string that is
supposed to come from application.properties.

This has worked fine in the past, but as a desperate attempt to get
q3stable DNE working this change just hard-codes the
application.properties strings rather than injecting them. Seems to
work locally.