### PR TITLE
ESTS-137690 Use q3stable dependencies where possible

### DIFF
--- a/dne-paqx-packaging/pom.xml
+++ b/dne-paqx-packaging/pom.xml
@@ -23,7 +23,7 @@
     </licenses>
     
     <properties>
-        <com.dell.cpsd.ess.version>1.0.0-SNAPSHOT</com.dell.cpsd.ess.version>
+        <com.dell.cpsd.ess.version>1.0.0-q3stable-SNAPSHOT</com.dell.cpsd.ess.version>
     </properties>
     
     <dependencies>

--- a/dne-paqx/pom.xml
+++ b/dne-paqx/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.dell.cpsd</groupId>
             <artifactId>common-client</artifactId>
-            <version>2.2.0-SNAPSHOT</version>
+            <version>2.2.0-q3stable-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.dell.cpsd</groupId>
             <artifactId>discovered-nodes-capabilities-client-java</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.0-q3stable-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -86,7 +86,7 @@
             <artifactId>engineering-standards-service-api</artifactId>
             <classifier>schemas</classifier>
             <type>zip</type>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-q3stable-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>com.dell.cpsd.sdk</groupId>
             <artifactId>SDKClient-driver</artifactId>
-            <version>1.01-SNAPSHOT</version>
+            <version>1.01-q3stable-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
All com.dell.cpsd dependencies in the q3table branches should point to
q3stable versions where they are available. If there is no q3stable
version available it means that it is an old version that is no longer
being built by master or q3stable branches and will not change in the
future. If there is a q3stable version it is being built by a q3stable
branch and we must consume that.