### PR TITLE
ESTS-136762 Temporary fix for compute api change

### DIFF
--- a/dne-paqx/src/test/java/com/dell/cpsd/paqx/dne/service/amqp/AmqpNodeServiceTest.java
+++ b/dne-paqx/src/test/java/com/dell/cpsd/paqx/dne/service/amqp/AmqpNodeServiceTest.java
@@ -195,10 +195,13 @@ public class AmqpNodeServiceTest
 
     private List<com.dell.cpsd.DiscoveredNode> buildNodeList(String uuid)
     {
-        com.dell.cpsd.DiscoveredNode discoveredNode = new com.dell.cpsd.DiscoveredNode(uuid,
-                com.dell.cpsd.DiscoveredNode.AllocationStatus.DISCOVERED);
-        com.dell.cpsd.DiscoveredNode addedNode = new com.dell.cpsd.DiscoveredNode(UUID.randomUUID().toString(),
-                com.dell.cpsd.DiscoveredNode.AllocationStatus.ADDED);
+        com.dell.cpsd.DiscoveredNode discoveredNode = new com.dell.cpsd.DiscoveredNode();
+        discoveredNode.setConvergedUuid(uuid);
+        discoveredNode.setAllocationStatus(com.dell.cpsd.DiscoveredNode.AllocationStatus.DISCOVERED);
+
+        com.dell.cpsd.DiscoveredNode addedNode = new com.dell.cpsd.DiscoveredNode();
+        addedNode.setConvergedUuid(UUID.randomUUID().toString());
+        addedNode.setAllocationStatus(com.dell.cpsd.DiscoveredNode.AllocationStatus.ADDED);
 
         List<com.dell.cpsd.DiscoveredNode> nodeList = new ArrayList<>();
         nodeList.add(discoveredNode);


### PR DESCRIPTION
As part of work to add the serial number, manufacturer and vendor to
the discovered nodes data the api was changed to include that
data. That changed the constructor arguments and broke DNE
compilation. This is a temporary change to adjust to those changes
until the full work is done.