### PR TITLE
[misc] Work around unit test failure

### DIFF
--- a/dne-paqx/src/test/java/com/dell/cpsd/paqx/dne/service/task/handler/preprocess/PingIdracTaskHandlerTest.java
+++ b/dne-paqx/src/test/java/com/dell/cpsd/paqx/dne/service/task/handler/preprocess/PingIdracTaskHandlerTest.java
@@ -126,7 +126,7 @@ public class PingIdracTaskHandlerTest
     @Test
     public void executeTask_ip_address_unreachable()
     {
-        String bogusIdracIpAddress = "1.0.0.0";
+        String bogusIdracIpAddress = "240.0.0.0";
 
         doReturn(this.response).when(this.handler).initializeResponse(this.job);
         doReturn(this.request).when(this.job).getInputParams();


### PR DESCRIPTION
Ping test was failing because 1.0.0.0 was reachable from my
environment. Updating to 240.0.0.0 which is currently "reserved for
future use".